### PR TITLE
Bugfix/define pathogen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ script:
 matrix:
   include:
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 1.3"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 1.3"
   - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 1.3"
+  - rvm: 2.1.7
+    env: PUPPET_GEM_VERSION="4.3.2" FACTER_GEM_VERSION="~> 2.4" HIERA_GEM_VERSION="~> 3.0"
 notifications:
   email: 'zan.loy@gmail.com'

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,33 @@
 source 'https://rubygems.org'
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 2.7']
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
 
-gem 'puppet', puppetversion
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
+
+if hieraversion = ENV['HIERA_GEM_VERSION']
+  gem 'hiera', hieraversion, :require => false
+else
+  gem 'hiera', :require => false
+end
 
 group :development, :test do
   gem 'puppet-blacksmith'
   gem 'puppet-lint'
   gem 'puppetlabs_spec_helper'
   gem 'rake', '>=0.9.2.2'
-  gem 'rspec', '< 3.0.0'
-  gem 'rspec-puppet'
+  gem 'rspec', '3.5.0'
+  gem 'rspec-core', '3.5.2'
+  gem 'rspec-puppet', '2.4.0'
+  gem 'listen', '3.0.8'
+  gem 'json', '1.8.3'
+  gem 'json_pure', '1.8.3'
   gem 'guard'
   gem 'guard-rake'
   gem 'guard-rspec'

--- a/manifests/pathogen.pp
+++ b/manifests/pathogen.pp
@@ -25,25 +25,26 @@ define vim::pathogen (
   file { ["${home_real}/.vim", "${home_real}/.vim/autoload", "${home_real}/.vim/bundle"]:
     ensure => directory,
     owner  => $user,
-  }
+  } ->
 
-  exec { 'curl-pathogen':
+  exec { "curl_pathogen_for_${user}":
     creates => "${home_real}/.vim/autoload/pathogen.vim",
     path    => ['/bin', '/usr/bin', '/usr/local/bin'],
     command => "curl -LSso ${home_real}/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim",
     require => Package['curl'],
-  }
+  } ->
 
   file { "${home_real}/.vim/autoload/pathogen.vim":
     owner   => $user,
-  }
+    require => Exec[ "curl_pathogen_for_${user}"],
+  } ->
 
-  vim::config { 'pathogen':
+  vim::config { "pathogen_${user}":
     user    => $user,
     content => 'execute pathogen#infect()',
     order   => '01',
   }
 
-  File["${home_real}/.vim"] ~> File["${home_real}/.vim/autoload"] ~> File["${home_real}/.vim/bundle"] ~> Exec['curl-pathogen'] ~> File["${home_real}/.vim/autoload/pathogen.vim"]
+  File["${home_real}/.vim"] -> File["${home_real}/.vim/autoload"] -> File["${home_real}/.vim/bundle"]
 
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -23,11 +23,12 @@ define vim::plugin (
   }
 
   exec { "${user}-${title}":
-    creates => "${home_real}/.vim/bundle/${title}",
+    creates => "${home_real}/.vim/bundle/${title}/.git",
     path    => ['/bin', '/usr/bin'],
-    command => "git clone ${url} ${home_real}/.vim/bundle/${title}",
+    cwd     => "${home_real}/.vim/bundle",
+    command => "git clone ${url} ${title}",
     user    => $user,
-    require => Package['git'],
+    require => [Package['git'], File["${home_real}/.vim/bundle"]],
   }
 
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,7 +47,7 @@ describe 'vim' do
         if values.has_key? :editor_set
           it { should contain_exec(values[:editor_set]) }
         else
-          it { should_not contain_exec }
+          it { should_not contain_exec('empty') }
         end
       end
     end

--- a/spec/defines/config_spec.rb
+++ b/spec/defines/config_spec.rb
@@ -1,38 +1,47 @@
 require 'spec_helper'
 
-title = 'colorscheme'
-content = 'colorscheme brg256'
 testcases = {
-  'case1' => { params: { user: 'user1', content: content }, expected_home: '/home/user1' },
-  'case2' => { params: { user: 'user2', content: content, home: '/home/local/user2' }, expected_home: '/home/local/user2' },
-  'case3' => { params: { user: 'root', content: content, order: '10' }, expected_home: '/root' },
+  'case1' => { title: 'vimrc_1', params: { user: 'user11', content: 'colorscheme brg256', order: '05'} },
+  'case2' => { title: 'vimrc_2', params: { user: 'user21', content: 'colorscheme brg256', order: '05'} },
+  'case3' => { title: 'vimrc_31', params: { user: 'user31', content: 'colorscheme brg256', home: '/home/local/user31'} },
 }
 
 describe 'vim::config', :type => :define do
   testcases.each do |name, values|
-    context "using test case '#{name}'" do
+    if values[:params][:home]
+      concat_file = "#{values[:params][:home]}/.vimrc"
+    else
+      if values[:params][:user] == 'root'
+        concat_file = '/root/.vimrc'
+      else
+        concat_file = "/home/#{values[:params][:user]}/.vimrc"
+      end
+    end
+    context "using test case '#{name}' for user #{values[:params][:user]}" do
       let(:facts) { { concat_basedir: '/tmp' } }
-      let(:title) { title }
+      let(:title) { "#{values[:title]}" }
       let(:params) { values[:params] }
-      context 'create the concat object' do
+      context "create the concat object '#{name}' for user #{values[:params][:user]}" do
         it do
-          should contain_concat("#{values[:expected_home]}/.vimrc")
+          should contain_concat("#{concat_file}")
+            .with({"owner"=>"#{values[:params][:user]}",
+                   "mode"=>"0644"})
         end
       end
-      context 'adds content to .vimrc' do
+      context "adds content to .vimrc '#{name}' for user #{values[:params][:user]}" do
         it do
           values[:params][:order] ||= '05'
           should contain_concat__fragment("#{values[:params][:user]}-vimrc-#{title}")
-            .with_target("#{values[:expected_home]}/.vimrc")
-            .with_content("#{content}\n")
+            .with_target("#{concat_file}")
+            .with_content("#{values[:params][:content]}\n")
             .with_order(values[:params][:order])
         end
       end
     end
   end #testcases.each
   context 'errors without user' do
-    let(:title) { title }
-    let(:params) { { content: content } }
+    let(:title) { testcases[:case1][:title] }
+    let(:params) { { content: testcases[:case1][:params][:content] } }
     it { expect { should compile }.to raise_error }
   end
 end #describe

--- a/spec/defines/pathogen_spec.rb
+++ b/spec/defines/pathogen_spec.rb
@@ -1,33 +1,47 @@
 require 'spec_helper'
 
 testcases = {
-  'case1' => { user: 'user1', params: {}, expected_home: '/home/user1' },
-  'case2' => { user: 'user2', params: { home: '/home/local/user2' }, expected_home: '/home/local/user2' },
-  'case3' => { user: 'root', params: {}, expected_home: '/root' },
+  'case1' => [
+    { user: 'user11', params: {}, expected_home: '/home/user11' },
+  ],
+  'case2' => [
+    { user: 'user21', params: { home: '/home/local/user21' }, expected_home: '/home/local/user21' },
+  ],
+  'case3' => [
+    { user: 'root', params: {}, expected_home: '/root' },
+    { user: 'user31', params: { home: '/home/local/user31' }, expected_home: '/home/local/user31' },
+  ],
+  'case4' => [
+    { user: 'root', params: {}, expected_home: '/root' },
+    { user: 'user41', params: { home: '/home/local/user41' }, expected_home: '/home/local/user41' },
+    { user: 'user42', params: {}, expected_home: '/home/user42' },
+  ]
 }
 
 describe 'vim::pathogen', :type => :define do
   testcases.each do |name, values|
-    context "using test case '#{name}'" do
-      let(:facts) { { concat_basedir: '/tmp' } }
-      let(:title) { values[:user] }
-      let(:params) { values[:params] }
-      context 'creates proper directories' do
-        it { should contain_file("#{values[:expected_home]}/.vim") }
-        it { should contain_file("#{values[:expected_home]}/.vim/autoload") }
-        it { should contain_file("#{values[:expected_home]}/.vim/bundle") }
-      end
-      context 'downloads pathogen.vim' do
-        it do
-          should contain_exec('curl-pathogen')
-            .with_command("curl -LSso #{values[:expected_home]}/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim")
-            .with_creates("#{values[:expected_home]}/.vim/autoload/pathogen.vim")
+    values.each do |user_values|
+      context "using test case '#{name}'" do
+        let(:facts) { { concat_basedir: '/tmp' } }
+        let(:title) { user_values[:user] }
+        let(:params) { user_values[:params] }
+        context 'creates proper directories' do
+          it { should contain_file("#{user_values[:expected_home]}/.vim") }
+          it { should contain_file("#{user_values[:expected_home]}/.vim/autoload") }
+          it { should contain_file("#{user_values[:expected_home]}/.vim/bundle") }
         end
-      end
-      context 'adds pathogen#infect to .vimrc' do
-        it do
-          should contain_vim__config('pathogen')
-            .with_content('execute pathogen#infect()')
+        context 'downloads pathogen.vim' do
+          it do
+            should contain_exec("curl_pathogen_for_#{user_values[:user]}")
+              .with_command("curl -LSso #{user_values[:expected_home]}/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim")
+              .with_creates("#{user_values[:expected_home]}/.vim/autoload/pathogen.vim")
+          end
+        end
+        context 'adds pathogen#infect to .vimrc' do
+          it do
+            should contain_vim__config("pathogen_#{user_values[:user]}")
+              .with_content('execute pathogen#infect()')
+          end
         end
       end
     end

--- a/spec/defines/plugin_spec.rb
+++ b/spec/defines/plugin_spec.rb
@@ -6,8 +6,9 @@ describe 'vim::plugin', :type => :define do
     let(:params) { {user: 'user1', url: 'https://github.com/tpope/vim-commentary.git'} }
     it do
       should contain_exec('user1-vim-commentary')
-        .with_creates('/home/user1/.vim/bundle/vim-commentary')
-        .with_command('git clone https://github.com/tpope/vim-commentary.git /home/user1/.vim/bundle/vim-commentary')
+        .with_creates('/home/user1/.vim/bundle/vim-commentary/.git')
+        .with_cwd('/home/user1/.vim/bundle')
+        .with_command('git clone https://github.com/tpope/vim-commentary.git vim-commentary')
         .with_user('user1')
     end
   end

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,2 +1,2 @@
 --color
---format documentation
+--format


### PR DESCRIPTION
- Bugfix define pathogen for multiple user:
  Before:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Exec[curl-pathogen] is already declared in file /etc/puppetlabs/code/environments/user1/modules/vim/manifests/pathogen.pp:30; cannot redeclare at /etc/puppetlabs/code/environments/user1/modules/vim/manifests/pathogen.pp:30 at /etc/puppetlabs/code/environments/user1/modules/vim/manifests/pathogen.pp:30:3 on node puppet-server
```

After:

```
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user1]/File[/home/user1/.vim]/ensure: created
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user1]/File[/home/user1/.vim/autoload]/ensure: created
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user1]/File[/home/user1/.vim/bundle]/ensure: created
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user1]/Exec[curl_pathogen_for_user1]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user1]/File[/home/user1/.vim/autoload/pathogen.vim]/owner: owner changed 'root' to 'user1'
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user2]/File[/home/user2/.vim]/ensure: created
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user2]/File[/home/user2/.vim/autoload]/ensure: created
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user2]/File[/home/user2/.vim/bundle]/ensure: created
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user2]/Exec[curl_pathogen_for_user2]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Vim::Pathogen[user2]/File[/home/user2/.vim/autoload/pathogen.vim]/owner: owner changed 'root' to 'user2'
Notice: /Stage[main]/Roles::Common/Vim::Plugin[puppet-user1]/Exec[user1-puppet-user1]/returns: executed successfully
Notice: /Stage[main]/Roles::Common/Vim::Plugin[puppet-user2]/Exec[user2-puppet-user2]/returns: executed successfully
```
- fix tests
- fix git clone and add  dependence on pathogen
  git clone error:

```
Error: git clone https://github.com/rodjek/vim-puppet /home/user2/.vim/bundle/puppet-user2 returned 128 instead of one of [0]
Error: /Stage[main]/Roles::Common/Vim::Plugin[puppet-user2]/Exec[user2-puppet-user2]/returns: change from notrun to 0 failed: git clone https://github.com/rodjek/vim-puppet /home/user2/.vim/bundle/puppet-user2 returned 128 instead of one of [0]
```
