### PR TITLE
WIP: allow per-user instances of vim::plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ Using [vim-commentary](https://github.com/tpope/vim-commentary) as an example.
 Be sure to install pathogen or the plugins won't load in vim for that user.
 
 ```
-vim::plugin { 'vim-commentary': url => 'https://github.com/tpope/vim-commentary.git' }
+vim::plugin { 'vim-commentary':
+  user => 'johndoe',
+  url  => 'https://github.com/tpope/vim-commentary.git',
+}
 ```
 
 Install a bundle of plugins recommended by this module's author. This will

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -1,7 +1,8 @@
 define vim::plugin (
   $user,
   $url,
-  $home = 'UNSET'
+  $name = $title,
+  $home = 'UNSET',
 ) {
 
   validate_string($user, $url)
@@ -22,11 +23,11 @@ define vim::plugin (
     }
   }
 
-  exec { "${user}-${title}":
-    creates => "${home_real}/.vim/bundle/${title}/.git",
+  exec { "vim::plugin-${user}-${title}":
+    creates => "${home_real}/.vim/bundle/${name}/.git",
     path    => ['/bin', '/usr/bin'],
     cwd     => "${home_real}/.vim/bundle",
-    command => "git clone ${url} ${title}",
+    command => "git clone ${url} ${name}",
     user    => $user,
     require => [Package['git'], File["${home_real}/.vim/bundle"]],
   }


### PR DESCRIPTION
The current version of this defined resource type allows one to
specify a user, but because the $title is being used as part of
the exec's command there is no way to specify the same plugin for
multiple users without getting a duplicate resource error. This
commit effectively creates a namevar `name` for this defined type,
which will allow the decoupling of the $title from the command.

Existing behavior is still maintained.
